### PR TITLE
feat: Add form screen with Cuit validation

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -4,7 +4,17 @@ import 'package:go_router/go_router.dart';
 final appRouter = GoRouter(
   routes: [
     GoRoute(path: '/', builder: (context, state) => const HomeScreen()),
-    GoRoute(path: '/cubits', builder: (context, state) => const CubitCounterScreen()),
-    GoRoute(path: '/bloc', builder: (context, state) => const BlocCounterScreen())
-  ]
+    GoRoute(
+      path: '/cubits',
+      builder: (context, state) => const CubitCounterScreen(),
+    ),
+    GoRoute(
+      path: '/bloc',
+      builder: (context, state) => const BlocCounterScreen(),
+    ),
+    GoRoute(
+      path: '/register',
+      builder: (context, state) => const RegisterScreen(),
+    ),
+  ],
 );

--- a/lib/presentation/blocs/register_cubit/register_cubit.dart
+++ b/lib/presentation/blocs/register_cubit/register_cubit.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:forms_app/presentation/inputs/inputs.dart';
+import 'package:formz/formz.dart';
 
 part 'register_state.dart';
 
@@ -11,7 +13,8 @@ class RegisterCubit extends Cubit<RegisterFormState> {
   }
 
   void updateUsername(String value) {
-    emit(state.copyWith(username: value));
+    final username = UsernameInput.dirty(value);
+    emit(state.copyWith(isValid: Formz.validate([username]), username: username));
   }
 
   void updateEmail(String value) {

--- a/lib/presentation/blocs/register_cubit/register_cubit.dart
+++ b/lib/presentation/blocs/register_cubit/register_cubit.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'register_state.dart';
+
+class RegisterCubit extends Cubit<RegisterFormState> {
+  RegisterCubit() : super(const RegisterFormState());
+
+  void onSubmit() {
+    print('Submit: $state');
+  }
+
+  void updateUsername(String value) {
+    emit(state.copyWith(username: value));
+  }
+
+  void updateEmail(String value) {
+    emit(state.copyWith(email: value));
+  }
+
+  void updatePassword(String value) {
+    emit(state.copyWith(password: value));
+  }
+}

--- a/lib/presentation/blocs/register_cubit/register_cubit.dart
+++ b/lib/presentation/blocs/register_cubit/register_cubit.dart
@@ -14,7 +14,12 @@ class RegisterCubit extends Cubit<RegisterFormState> {
 
   void updateUsername(String value) {
     final username = UsernameInput.dirty(value);
-    emit(state.copyWith(isValid: Formz.validate([username]), username: username));
+    emit(
+      state.copyWith(
+        isValid: Formz.validate([username, state.password]),
+        username: username,
+      ),
+    );
   }
 
   void updateEmail(String value) {
@@ -22,6 +27,12 @@ class RegisterCubit extends Cubit<RegisterFormState> {
   }
 
   void updatePassword(String value) {
-    emit(state.copyWith(password: value));
+    final password = PasswordInput.dirty(value);
+    emit(
+      state.copyWith(
+        isValid: Formz.validate([password, state.username]),
+        password: password,
+      ),
+    );
   }
 }

--- a/lib/presentation/blocs/register_cubit/register_cubit.dart
+++ b/lib/presentation/blocs/register_cubit/register_cubit.dart
@@ -8,7 +8,15 @@ part 'register_state.dart';
 class RegisterCubit extends Cubit<RegisterFormState> {
   RegisterCubit() : super(const RegisterFormState());
 
-  void onSubmit() {
+  void onSubmit() async {
+    emit(
+      state.copyWith(
+        status: FormStatus.validating,
+        username: UsernameInput.dirty(state.username.value),
+        password: PasswordInput.dirty(state.password.value),
+        isValid: Formz.validate([state.username, state.password]),
+      ),
+    );
     print('Submit: $state');
   }
 

--- a/lib/presentation/blocs/register_cubit/register_cubit.dart
+++ b/lib/presentation/blocs/register_cubit/register_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:forms_app/presentation/inputs/email_input.dart';
 import 'package:forms_app/presentation/inputs/inputs.dart';
 import 'package:formz/formz.dart';
 
@@ -14,6 +15,7 @@ class RegisterCubit extends Cubit<RegisterFormState> {
         status: FormStatus.validating,
         username: UsernameInput.dirty(state.username.value),
         password: PasswordInput.dirty(state.password.value),
+        email: EmailInput.dirty(state.email.value),
         isValid: Formz.validate([state.username, state.password]),
       ),
     );
@@ -24,21 +26,27 @@ class RegisterCubit extends Cubit<RegisterFormState> {
     final username = UsernameInput.dirty(value);
     emit(
       state.copyWith(
-        isValid: Formz.validate([username, state.password]),
+        isValid: Formz.validate([username, state.password, state.email]),
         username: username,
       ),
     );
   }
 
   void updateEmail(String value) {
-    emit(state.copyWith(email: value));
+    final email = EmailInput.dirty(value);
+    emit(
+      state.copyWith(
+        isValid: Formz.validate([email, state.username, state.password]),
+        email: email,
+      ),
+    );
   }
 
   void updatePassword(String value) {
     final password = PasswordInput.dirty(value);
     emit(
       state.copyWith(
-        isValid: Formz.validate([password, state.username]),
+        isValid: Formz.validate([password, state.username, state.email]),
         password: password,
       ),
     );

--- a/lib/presentation/blocs/register_cubit/register_state.dart
+++ b/lib/presentation/blocs/register_cubit/register_state.dart
@@ -7,14 +7,14 @@ class RegisterFormState extends Equatable {
   final bool isValid;
   final UsernameInput username;
   final String email;
-  final String password;
+  final PasswordInput password;
 
   const RegisterFormState({
     this.status = FormStatus.invalid,
     this.isValid = false,
     this.username = const UsernameInput.pure(),
     this.email = '',
-    this.password = '',
+    this.password = const PasswordInput.pure(),
   });
 
   RegisterFormState copyWith({
@@ -22,7 +22,7 @@ class RegisterFormState extends Equatable {
     bool? isValid,
     UsernameInput? username,
     String? email,
-    String? password,
+    PasswordInput? password,
   }) {
     return RegisterFormState(
       status: status ?? this.status,

--- a/lib/presentation/blocs/register_cubit/register_state.dart
+++ b/lib/presentation/blocs/register_cubit/register_state.dart
@@ -1,0 +1,34 @@
+part of 'register_cubit.dart';
+
+enum FormStatus { invalid, valid, validating, posting }
+
+class RegisterFormState extends Equatable {
+  final FormStatus status;
+  final String username;
+  final String email;
+  final String password;
+
+  const RegisterFormState({
+    this.status = FormStatus.invalid,
+    this.username = '',
+    this.email = '',
+    this.password = '',
+  });
+
+  RegisterFormState copyWith({
+    FormStatus? status,
+    String? username,
+    String? email,
+    String? password,
+  }) {
+    return RegisterFormState(
+      status: status ?? this.status,
+      username: username ?? this.username,
+      email: email ?? this.email,
+      password: password ?? this.password,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, username, email, password];
+}

--- a/lib/presentation/blocs/register_cubit/register_state.dart
+++ b/lib/presentation/blocs/register_cubit/register_state.dart
@@ -6,14 +6,14 @@ class RegisterFormState extends Equatable {
   final FormStatus status;
   final bool isValid;
   final UsernameInput username;
-  final String email;
+  final EmailInput email;
   final PasswordInput password;
 
   const RegisterFormState({
     this.status = FormStatus.invalid,
     this.isValid = false,
     this.username = const UsernameInput.pure(),
-    this.email = '',
+    this.email = const EmailInput.pure(),
     this.password = const PasswordInput.pure(),
   });
 
@@ -21,7 +21,7 @@ class RegisterFormState extends Equatable {
     FormStatus? status,
     bool? isValid,
     UsernameInput? username,
-    String? email,
+    EmailInput? email,
     PasswordInput? password,
   }) {
     return RegisterFormState(

--- a/lib/presentation/blocs/register_cubit/register_state.dart
+++ b/lib/presentation/blocs/register_cubit/register_state.dart
@@ -4,25 +4,29 @@ enum FormStatus { invalid, valid, validating, posting }
 
 class RegisterFormState extends Equatable {
   final FormStatus status;
-  final String username;
+  final bool isValid;
+  final UsernameInput username;
   final String email;
   final String password;
 
   const RegisterFormState({
     this.status = FormStatus.invalid,
-    this.username = '',
+    this.isValid = false,
+    this.username = const UsernameInput.pure(),
     this.email = '',
     this.password = '',
   });
 
   RegisterFormState copyWith({
     FormStatus? status,
-    String? username,
+    bool? isValid,
+    UsernameInput? username,
     String? email,
     String? password,
   }) {
     return RegisterFormState(
       status: status ?? this.status,
+      isValid: isValid ?? this.isValid,
       username: username ?? this.username,
       email: email ?? this.email,
       password: password ?? this.password,
@@ -30,5 +34,5 @@ class RegisterFormState extends Equatable {
   }
 
   @override
-  List<Object?> get props => [status, username, email, password];
+  List<Object?> get props => [status, isValid, username, email, password];
 }

--- a/lib/presentation/inputs/email_input.dart
+++ b/lib/presentation/inputs/email_input.dart
@@ -1,0 +1,40 @@
+import 'package:formz/formz.dart';
+
+enum EmailInputError { empty, format }
+
+class EmailInput extends FormzInput<String, EmailInputError> {
+  const EmailInput.pure() : super.pure('');
+
+  const EmailInput.dirty([String value = '']) : super.dirty(value);
+
+  String? get errorMessage {
+    if (isValid || isPure) {
+      return null;
+    }
+
+    if (displayError == EmailInputError.empty) {
+      return 'Email cannot be empty';
+    } else if (displayError == EmailInputError.format) {
+      return 'Email is not in a valid format';
+    } else {
+      return 'Invalid email';
+    }
+  }
+
+  @override
+  EmailInputError? validator(String value) {
+    if (value.isEmpty || value.trim().isEmpty) {
+      return EmailInputError.empty;
+    }
+
+    final emailRegex = RegExp(
+      r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$',
+    );
+
+    if (!emailRegex.hasMatch(value)) {
+      return EmailInputError.format;
+    }
+
+    return null;
+  }
+}

--- a/lib/presentation/inputs/inputs.dart
+++ b/lib/presentation/inputs/inputs.dart
@@ -1,0 +1,1 @@
+export 'username_input.dart';

--- a/lib/presentation/inputs/inputs.dart
+++ b/lib/presentation/inputs/inputs.dart
@@ -1,1 +1,2 @@
 export 'username_input.dart';
+export 'password_input.dart';

--- a/lib/presentation/inputs/inputs.dart
+++ b/lib/presentation/inputs/inputs.dart
@@ -1,2 +1,3 @@
 export 'username_input.dart';
 export 'password_input.dart';
+export 'email_input.dart';

--- a/lib/presentation/inputs/password_input.dart
+++ b/lib/presentation/inputs/password_input.dart
@@ -1,0 +1,22 @@
+import 'package:formz/formz.dart';
+
+enum PasswordInputError { empty, length }
+
+class PasswordInput extends FormzInput<String, PasswordInputError> {
+  const PasswordInput.pure() : super.pure('');
+
+  const PasswordInput.dirty([String value = '']) : super.dirty(value);
+
+  @override
+  PasswordInputError? validator(String value) {
+    if (value.isEmpty || value.trim().isEmpty) {
+      return PasswordInputError.empty;
+    }
+
+    if (value.length < 8) {
+      return PasswordInputError.length;
+    }
+
+    return null;
+  }
+}

--- a/lib/presentation/inputs/password_input.dart
+++ b/lib/presentation/inputs/password_input.dart
@@ -7,6 +7,20 @@ class PasswordInput extends FormzInput<String, PasswordInputError> {
 
   const PasswordInput.dirty([String value = '']) : super.dirty(value);
 
+  String? get errorMessage {
+    if (isValid || isPure) {
+      return null;
+    }
+
+    if (displayError == PasswordInputError.empty) {
+      return 'Password cannot be empty';
+    } else if (displayError == PasswordInputError.length) {
+      return 'Password must be at least 8 characters long';
+    } else {
+      return 'Invalid password';
+    }
+  }
+
   @override
   PasswordInputError? validator(String value) {
     if (value.isEmpty || value.trim().isEmpty) {

--- a/lib/presentation/inputs/username_input.dart
+++ b/lib/presentation/inputs/username_input.dart
@@ -1,14 +1,25 @@
 import 'package:formz/formz.dart';
 
-enum UsernameInputError {
-  empty, 
-  length
-}
+enum UsernameInputError { empty, length }
 
 class UsernameInput extends FormzInput<String, UsernameInputError> {
   const UsernameInput.pure() : super.pure('');
 
   const UsernameInput.dirty([String value = '']) : super.dirty(value);
+
+  String? get errorMessage {
+    if (isValid || isPure) {
+      return null;
+    }
+
+    if (displayError == UsernameInputError.empty) {
+      return 'Username cannot be empty';
+    } else if (displayError == UsernameInputError.length) {
+      return 'Username must be at least 6 characters long';
+    } else {
+      return 'Invalid username';
+    }
+  }
 
   @override
   UsernameInputError? validator(String value) {

--- a/lib/presentation/inputs/username_input.dart
+++ b/lib/presentation/inputs/username_input.dart
@@ -1,0 +1,25 @@
+import 'package:formz/formz.dart';
+
+enum UsernameInputError {
+  empty, 
+  length
+}
+
+class UsernameInput extends FormzInput<String, UsernameInputError> {
+  const UsernameInput.pure() : super.pure('');
+
+  const UsernameInput.dirty([String value = '']) : super.dirty(value);
+
+  @override
+  UsernameInputError? validator(String value) {
+    if (value.isEmpty || value.trim().isEmpty) {
+      return UsernameInputError.empty;
+    }
+
+    if (value.length < 6) {
+      return UsernameInputError.length;
+    }
+
+    return null;
+  }
+}

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -7,7 +7,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body:ListView(
+      body: ListView(
         children: [
           ListTile(
             title: const Text('Cubits'),
@@ -23,10 +23,16 @@ class HomeScreen extends StatelessWidget {
           ),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 10),
-            child: Divider()
-          )
+            child: Divider(),
+          ),
+          ListTile(
+            title: const Text('New User'),
+            subtitle: const Text('A simple register form'),
+            trailing: Icon(Icons.arrow_forward_ios_rounded),
+            onTap: () => context.push('/register'),
+          ),
         ],
-      )
+      ),
     );
   }
 }

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:forms_app/presentation/widgets/widgets.dart';
 
 class RegisterScreen extends StatelessWidget {
   const RegisterScreen({super.key});
@@ -17,6 +18,52 @@ class _RegisterView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        child: SingleChildScrollView(
+          child: Column(
+            children: const [
+              FlutterLogo(size: 100),
+              _RegisterForm(),
+
+              SizedBox(height: 20)
+            ],
+          ),
+        ),
+      )
+    );
+  }
+}
+
+class _RegisterForm extends StatelessWidget {
+  const _RegisterForm();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      child: Column(
+        children: [
+          CustomTextFormField(
+            label: 'Username',
+          ),
+          const SizedBox(height: 10),
+          CustomTextFormField(
+            label: 'Email',
+          ),
+          const SizedBox(height: 10),
+          CustomTextFormField(
+            label: 'Password',
+            obscureText: true,
+          ),
+          const SizedBox(height: 20),
+          FilledButton.tonalIcon(
+              onPressed: () {},
+              icon: const Icon(Icons.save),
+              label: const Text('Sign Up')
+          ),
+        ],
+      )
+    );
   }
 }

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class RegisterScreen extends StatelessWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('New User')),
+      body: const _RegisterView(),
+    );
+  }
+}
+
+class _RegisterView extends StatelessWidget {
+  const _RegisterView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -12,7 +12,7 @@ class RegisterScreen extends StatelessWidget {
       appBar: AppBar(title: Text('New User')),
       body: BlocProvider(
         create: (context) => RegisterCubit(),
-        child: const _RegisterView()
+        child: const _RegisterView(),
       ),
     );
   }
@@ -31,65 +31,49 @@ class _RegisterView extends StatelessWidget {
             children: const [
               FlutterLogo(size: 100),
               _RegisterForm(),
-              SizedBox(height: 20)
+              SizedBox(height: 20),
             ],
           ),
         ),
-      )
+      ),
     );
   }
 }
 
-class _RegisterForm extends StatefulWidget {
+class _RegisterForm extends StatelessWidget {
   const _RegisterForm();
-
-  @override
-  State<_RegisterForm> createState() => _RegisterFormState();
-}
-
-class _RegisterFormState extends State<_RegisterForm> {
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
     final registerCubit = context.watch<RegisterCubit>();
+    final username = registerCubit.state.username;
+    final password = registerCubit.state.password;
 
     return Form(
-      key: _formKey,
       child: Column(
         children: [
           CustomTextFormField(
-            onChanged: (value) {
-              registerCubit.updateUsername(value);
-              _formKey.currentState?.validate();
-            },
-            validator: (value) {
-              if (value == null || value.isEmpty || value.trim().isEmpty) {
-                return 'Username is required';
-              }
-
-              if (value.length < 6) {
-                return 'Username must be at least 6 characters long';
-              }
-
-              return null;
-            },
             label: 'Username',
+            onChanged: (value) => registerCubit.updateUsername(value),
+            errorText: username.isPure || username.isValid
+                ? null
+                : 'Invalid username',
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
             onChanged: (value) {
               registerCubit.updateEmail(value);
-              _formKey.currentState?.validate();
             },
             validator: (value) {
               if (value == null || value.isEmpty || value.trim().isEmpty) {
                 return 'Email is required';
               }
 
-              final emailRegex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$');
+              final emailRegex = RegExp(
+                r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$',
+              );
 
-              if (!emailRegex .hasMatch(value)) {
+              if (!emailRegex.hasMatch(value)) {
                 return 'Please enter a valid email address';
               }
 
@@ -99,40 +83,23 @@ class _RegisterFormState extends State<_RegisterForm> {
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
-            onChanged: (value) {
-              registerCubit.updatePassword(value);
-              _formKey.currentState?.validate();
-            },
-            validator: (value) {
-              if (value == null || value.isEmpty || value.trim().isEmpty) {
-                return 'Password is required';
-              }
-
-              if (value.length < 8) {
-                return 'Password must be at least 8 characters long';
-              }
-
-              return null;
-            },
             label: 'Password',
+            onChanged: (value) => registerCubit.updatePassword(value),
+            errorText: password.isPure || password.isValid
+                ? null
+                : 'Invalid password',
             obscureText: true,
           ),
           const SizedBox(height: 20),
           FilledButton.tonalIcon(
-              onPressed: () {
-                // bool? isValid = _formKey.currentState?.validate();
-
-                // if (isValid == null || !isValid) {
-                //   return;
-                // }
-
-                registerCubit.onSubmit();
-              },
-              icon: const Icon(Icons.save),
-              label: const Text('Sign Up')
+            onPressed: () {
+              registerCubit.onSubmit();
+            },
+            icon: const Icon(Icons.save),
+            label: const Text('Sign Up'),
           ),
         ],
-      )
+      ),
     );
   }
 }

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -47,6 +47,7 @@ class _RegisterForm extends StatelessWidget {
   Widget build(BuildContext context) {
     final registerCubit = context.watch<RegisterCubit>();
     final username = registerCubit.state.username;
+    final email = registerCubit.state.email;
     final password = registerCubit.state.password;
 
     return Form(
@@ -59,25 +60,9 @@ class _RegisterForm extends StatelessWidget {
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
-            onChanged: (value) {
-              registerCubit.updateEmail(value);
-            },
-            validator: (value) {
-              if (value == null || value.isEmpty || value.trim().isEmpty) {
-                return 'Email is required';
-              }
-
-              final emailRegex = RegExp(
-                r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$',
-              );
-
-              if (!emailRegex.hasMatch(value)) {
-                return 'Please enter a valid email address';
-              }
-
-              return null;
-            },
             label: 'Email',
+            onChanged: (value) => registerCubit.updateEmail(value),
+            errorText: email.errorMessage,
           ),
           const SizedBox(height: 10),
           CustomTextFormField(

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -55,9 +55,7 @@ class _RegisterForm extends StatelessWidget {
           CustomTextFormField(
             label: 'Username',
             onChanged: (value) => registerCubit.updateUsername(value),
-            errorText: username.isPure || username.isValid
-                ? null
-                : 'Invalid username',
+            errorText: username.errorMessage,
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
@@ -85,9 +83,7 @@ class _RegisterForm extends StatelessWidget {
           CustomTextFormField(
             label: 'Password',
             onChanged: (value) => registerCubit.updatePassword(value),
-            errorText: password.isPure || password.isValid
-                ? null
-                : 'Invalid password',
+            errorText: password.errorMessage,
             obscureText: true,
           ),
           const SizedBox(height: 20),

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:forms_app/presentation/blocs/register_cubit/register_cubit.dart';
 import 'package:forms_app/presentation/widgets/widgets.dart';
 
 class RegisterScreen extends StatelessWidget {
@@ -8,7 +10,10 @@ class RegisterScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('New User')),
-      body: const _RegisterView(),
+      body: BlocProvider(
+        create: (context) => RegisterCubit(),
+        child: const _RegisterView()
+      ),
     );
   }
 }
@@ -26,7 +31,6 @@ class _RegisterView extends StatelessWidget {
             children: const [
               FlutterLogo(size: 100),
               _RegisterForm(),
-
               SizedBox(height: 20)
             ],
           ),
@@ -45,18 +49,20 @@ class _RegisterForm extends StatefulWidget {
 
 class _RegisterFormState extends State<_RegisterForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  String username = '';
-  String email = '';
-  String password = '';
 
   @override
   Widget build(BuildContext context) {
+    final registerCubit = context.watch<RegisterCubit>();
+
     return Form(
       key: _formKey,
       child: Column(
         children: [
           CustomTextFormField(
-            onChanged: (value) => username = value,
+            onChanged: (value) {
+              registerCubit.updateUsername(value);
+              _formKey.currentState?.validate();
+            },
             validator: (value) {
               if (value == null || value.isEmpty || value.trim().isEmpty) {
                 return 'Username is required';
@@ -72,7 +78,10 @@ class _RegisterFormState extends State<_RegisterForm> {
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
-            onChanged: (value) => email = value,
+            onChanged: (value) {
+              registerCubit.updateEmail(value);
+              _formKey.currentState?.validate();
+            },
             validator: (value) {
               if (value == null || value.isEmpty || value.trim().isEmpty) {
                 return 'Email is required';
@@ -90,7 +99,10 @@ class _RegisterFormState extends State<_RegisterForm> {
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
-            onChanged: (value) => password = value,
+            onChanged: (value) {
+              registerCubit.updatePassword(value);
+              _formKey.currentState?.validate();
+            },
             validator: (value) {
               if (value == null || value.isEmpty || value.trim().isEmpty) {
                 return 'Password is required';
@@ -114,7 +126,7 @@ class _RegisterFormState extends State<_RegisterForm> {
                   return;
                 }
 
-                print('$username - $email - $password');
+                registerCubit.onSubmit();
               },
               icon: const Icon(Icons.save),
               label: const Text('Sign Up')

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -36,29 +36,86 @@ class _RegisterView extends StatelessWidget {
   }
 }
 
-class _RegisterForm extends StatelessWidget {
+class _RegisterForm extends StatefulWidget {
   const _RegisterForm();
+
+  @override
+  State<_RegisterForm> createState() => _RegisterFormState();
+}
+
+class _RegisterFormState extends State<_RegisterForm> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  String username = '';
+  String email = '';
+  String password = '';
 
   @override
   Widget build(BuildContext context) {
     return Form(
+      key: _formKey,
       child: Column(
         children: [
           CustomTextFormField(
+            onChanged: (value) => username = value,
+            validator: (value) {
+              if (value == null || value.isEmpty || value.trim().isEmpty) {
+                return 'Username is required';
+              }
+
+              if (value.length < 6) {
+                return 'Username must be at least 6 characters long';
+              }
+
+              return null;
+            },
             label: 'Username',
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
+            onChanged: (value) => email = value,
+            validator: (value) {
+              if (value == null || value.isEmpty || value.trim().isEmpty) {
+                return 'Email is required';
+              }
+
+              final emailRegex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,5}$');
+
+              if (!emailRegex .hasMatch(value)) {
+                return 'Please enter a valid email address';
+              }
+
+              return null;
+            },
             label: 'Email',
           ),
           const SizedBox(height: 10),
           CustomTextFormField(
+            onChanged: (value) => password = value,
+            validator: (value) {
+              if (value == null || value.isEmpty || value.trim().isEmpty) {
+                return 'Password is required';
+              }
+
+              if (value.length < 8) {
+                return 'Password must be at least 8 characters long';
+              }
+
+              return null;
+            },
             label: 'Password',
             obscureText: true,
           ),
           const SizedBox(height: 20),
           FilledButton.tonalIcon(
-              onPressed: () {},
+              onPressed: () {
+                bool? isValid = _formKey.currentState?.validate();
+
+                if (isValid == null || !isValid) {
+                  return;
+                }
+
+                print('$username - $email - $password');
+              },
               icon: const Icon(Icons.save),
               label: const Text('Sign Up')
           ),

--- a/lib/presentation/screens/register_screen.dart
+++ b/lib/presentation/screens/register_screen.dart
@@ -120,11 +120,11 @@ class _RegisterFormState extends State<_RegisterForm> {
           const SizedBox(height: 20),
           FilledButton.tonalIcon(
               onPressed: () {
-                bool? isValid = _formKey.currentState?.validate();
+                // bool? isValid = _formKey.currentState?.validate();
 
-                if (isValid == null || !isValid) {
-                  return;
-                }
+                // if (isValid == null || !isValid) {
+                //   return;
+                // }
 
                 registerCubit.onSubmit();
               },

--- a/lib/presentation/screens/screens.dart
+++ b/lib/presentation/screens/screens.dart
@@ -1,3 +1,4 @@
 export 'home_screen.dart';
 export 'cubit_counter_screen.dart';
 export 'bloc_counter_screen.dart';
+export 'register_screen.dart';

--- a/lib/presentation/widgets/inputs/custom_text_form_field.dart
+++ b/lib/presentation/widgets/inputs/custom_text_form_field.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class CustomTextFormField extends StatelessWidget {
+  final String? label;
+  final String? hintText;
+  final String? errorText;
+  final Function(String)? onChanged;
+  final String? Function(String?)? validator;
+  final bool obscureText;
+
+  const CustomTextFormField({
+    super.key,
+    this.label,
+    this.hintText,
+    this.errorText,
+    this.onChanged,
+    this.validator,
+    this.obscureText = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    final border = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(40),
+    );
+    return TextFormField(
+      onChanged: onChanged,
+      validator: validator,
+      obscureText: obscureText,
+      decoration: InputDecoration(
+        enabledBorder: border,
+        focusedBorder: border.copyWith(
+          borderSide: BorderSide(color: colors.primary)
+        ),
+        errorBorder: border.copyWith(
+          borderSide: BorderSide(color: Colors.red.shade800)
+        ),
+        focusedErrorBorder: border.copyWith(
+            borderSide: BorderSide(color: Colors.red.shade800)
+        ),
+        isDense: true,
+        label: label != null ? Text(label!) : null,
+        hintText: hintText,
+        focusColor: colors.primary,
+        errorText: errorText,
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/widgets.dart
+++ b/lib/presentation/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'inputs/custom_text_form_field.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -96,6 +96,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  formz:
+    dependency: "direct main"
+    description:
+      name: formz
+      sha256: "40a8a8487a640c54156b5aed9642e55e84e53772e15d14f60644d05beaa0781b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0+1"
   go_router:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^9.1.1
+  formz: ^0.5.0+1
   go_router: ^16.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This pull request introduces a new user registration feature, including form validation and navigation updates. It adds a `RegisterScreen` with a custom form component, integrates a `RegisterCubit` for state management, and updates routing and navigation to support the new screen. Additionally, reusable input validation logic has been implemented using the `Formz` package.

### Routing Updates:
* Added a new route for the `RegisterScreen` in `lib/config/router/app_router.dart`.
* Updated `HomeScreen` to include a navigation option for the registration form.

### Registration Feature:
* Created `RegisterScreen` with a form for username, email, and password inputs, managed by `RegisterCubit`.
* Added `RegisterCubit` and `RegisterFormState` for handling form state and validation logic. [[1]](diffhunk://#diff-48ae4022d41aa02aeac9965a05c10898992fc91284a98bbaca0c084b2ab8fdf5R1-R54) [[2]](diffhunk://#diff-ee31ebe2a872fa2e9c264b96751f50b199dd80a8da97fa651b648d2301ab51e0R1-R38)

### Input Validation:
* Implemented reusable input validation classes (`EmailInput`, `PasswordInput`, `UsernameInput`) using `Formz`. These classes validate inputs for format, length, and non-empty values. [[1]](diffhunk://#diff-5aa760a1f8adac4e73e8ba2c81c791cfdf1158a739c8ee39e7d7eb481547484dR1-R40) [[2]](diffhunk://#diff-39f973f028e83ca0bfe74b230216113dfe1d49483d1df94a184ee32e6b7b20fdR1-R36) [[3]](diffhunk://#diff-2fccb209cc2cf0a4390945d807b4922ee0b7e2f20f631df6dcf3b5c941f3f048R1-R36)
* Exported input validation classes in `lib/presentation/inputs/inputs.dart` for reuse.

### UI Components:
* Added `CustomTextFormField` widget for consistent input styling and error handling.
* Exported the `CustomTextFormField` in `lib/presentation/widgets/widgets.dart`.

### Dependency Updates:
* Added the `Formz` package to `pubspec.yaml` for managing input validation.